### PR TITLE
Length's recording bug

### DIFF
--- a/src/Value/Length.php
+++ b/src/Value/Length.php
@@ -33,6 +33,7 @@ class Length implements Value
      */
     public function __toString(): string
     {
-        return date('i:s', floor($this->length/1000));
+        return $this->length;
+        //date('i:s', floor($this->length/1000));
     }
 }

--- a/src/Value/Property/TrackDisplayNumberTrait.php
+++ b/src/Value/Property/TrackDisplayNumberTrait.php
@@ -36,7 +36,7 @@ trait TrackDisplayNumberTrait
      */
     private function setTrackDisplayNumberFromArray(array $input): void
     {
-        $this->length = is_null($trackDisplayNumber = ArrayAccess::getString($input, 'number'))
+        $this->trackDisplayNumber = is_null($trackDisplayNumber = ArrayAccess::getString($input, 'number'))
             ? new TrackDisplayNumber
             : new TrackDisplayNumber($trackDisplayNumber);
     }


### PR DESCRIPTION
Hi, 

I corrected the bug about the length/trackDisplayNumber function. But there is still a bug (?) that causes the returned length is 0 instead of the song's duration. I also modified the returned length value to the raw data instead of a formatted one: it seems to me that the conversion is more flexible if the developer can choose the format rather than impose it directly in the code.