### PR TITLE
Fixed loading recording from array

### DIFF
--- a/src/Value/Property/RecordingTrait.php
+++ b/src/Value/Property/RecordingTrait.php
@@ -34,9 +34,15 @@ trait RecordingTrait
      *
      * @return void
      */
-    private function setRecordingFromArray(array $input): void
+    private function setRecordingFromArray(array $input, ?string $key = 'recording'): void
     {
-        $this->recording = is_null($recording = ArrayAccess::getString($input, 'recording'))
+        if (is_null($key)) {
+            $this->recording = new Recording($input);
+
+            return;
+        }
+
+        $this->recording = is_null($recording = ArrayAccess::getString($input, $key))
             ? new Recording()
             : new Recording($recording);
     }


### PR DESCRIPTION
@XenosEleatikos Now I moved on to tracks and ran into the issue that the recordings are empty. I tracked it down to the RecordingTrait.php as it looks different from the ArtistTrait.php.

This fix makes the RecordingTrait behave the same way as the ArtistTrait, this way you get a populated recording.

I am using this code that gave me the issue:
```php
$trackFilter = new RecordingFilter();
		$trackFilter->addRecordingNameWithAccents(new Name($value));
		$pageFilter = new PageFilter(0, 2);

		$trackList = $this->api->api()->search()->recording(
			$trackFilter,
			$pageFilter
		);

		$tracks = [];

		foreach ($trackList as $track) {
			$tracks[] = $this->api->api()->lookup()->recording(
				new MBID($track->getRecording()->getMBID()),
				$this->recordingFields
			);
		}
```