### PR TITLE
Add First Release Date as Recording value

### DIFF
--- a/src/Value/FirstReleaseDate.php
+++ b/src/Value/FirstReleaseDate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MusicBrainz\Value;
+
+/**
+ * The first release date
+ */
+class FirstReleaseDate extends Date
+{
+}

--- a/src/Value/Property/FirstReleaseDateTrait.php
+++ b/src/Value/Property/FirstReleaseDateTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MusicBrainz\Value\Property;
+
+use MusicBrainz\Helper\ArrayAccess;
+use MusicBrainz\Value\FirstReleaseDate;
+
+/**
+ * Provides a getter for the first release date.
+ */
+trait FirstReleaseDateTrait
+{
+    /**
+     * The first release date
+     *
+     * @var FirstReleaseDate
+     */
+    public FirstReleaseDate $firstReleaseDate;
+
+    /**
+     * Returns the first release date.
+     *
+     * @return FirstReleaseDate
+     */
+    public function getFirstReleaseDate(): FirstReleaseDate
+    {
+        return $this->firstReleaseDate;
+    }
+
+    /**
+     * Sets the first release date by extracting it from a given input array.
+     *
+     * @param array $input An array returned by the webservice
+     *
+     * @return void
+     */
+    private function setFirstReleaseDateFromArray(array $input): void
+    {
+        $this->firstReleaseDate = is_null($firstReleaseDate = ArrayAccess::getString($input, 'first-release-date'))
+            ? new FirstReleaseDate()
+            : new FirstReleaseDate($firstReleaseDate);
+    }
+}

--- a/src/Value/Recording.php
+++ b/src/Value/Recording.php
@@ -21,6 +21,7 @@ class Recording implements Value
     use Property\MBIDTrait;
     use Property\LengthTrait;
     use Property\TitleTrait;
+    use Property\FirstReleaseDateTrait;
     use Property\AliasesTrait;
     use Property\IpisTrait;
     use Property\CountryTrait;
@@ -49,6 +50,7 @@ class Recording implements Value
         $this->setMbidFromArray($recording);
         $this->setLengthFromArray($recording);
         $this->setTitleFromArray($recording);
+        $this->setFirstReleaseDateFromArray($recording);
         $this->setAliasesFromArray($recording);
         $this->setIpisFromArray($recording);
         $this->setCountryFromArray($recording);


### PR DESCRIPTION
The MusicBrainz API has a `first-release-date` value for a recording. This PR adds the property to the recording instance.