### PR TITLE
Fixed typo in key name for artist credit

### DIFF
--- a/src/Value/Property/ArtistCreditsTrait.php
+++ b/src/Value/Property/ArtistCreditsTrait.php
@@ -36,7 +36,7 @@ trait ArtistCreditsTrait
      *
      * @return void
      */
-    private function setArtistCreditsFromArray(array $input, string $key = 'artist-credits'): void
+    private function setArtistCreditsFromArray(array $input, string $key = 'artist-credit'): void
     {
         $this->artistCredits = is_null($artistCredits = ArrayAccess::getArray($input, $key))
             ? new ArtistCreditList()


### PR DESCRIPTION
The APi returns credited artists as `artist-credit`. This PR fixes the typo.

For example this URL: `https://musicbrainz.org/ws/2/recording?fmt=json&query="Lyin' eyes"`